### PR TITLE
fix 🔨 : typo fixed 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An API wrapper library for opensea api.
 
 ## Installation
 
-```python
+```bash
 pip3 install opensea
 ```
 


### PR DESCRIPTION
Fixed a typo in readme which should use bash as its syntax instead of python as it is a shell command